### PR TITLE
Fix strict standards error messages for PHP 5.6

### DIFF
--- a/Text/Diff.php
+++ b/Text/Diff.php
@@ -208,7 +208,7 @@ class Text_Diff {
      * @param string $line  The line to trim.
      * @param integer $key  The index of the line in the array. Not used.
      */
-    function trimNewlines(&$line, $key)
+    static function trimNewlines(&$line, $key)
     {
         $line = str_replace(array("\n", "\r"), '', $line);
     }


### PR DESCRIPTION
Hello,

On PHP 5.6 (PHP 5.6.12-0+deb8u1), Text_Diff raises some strict standards error messages.

This PR should fix this problem.
