### PR TITLE
Fix: Do not use `string`s as arguments to `assert()`

### DIFF
--- a/Text/Diff/Engine/native.php
+++ b/Text/Diff/Engine/native.php
@@ -332,7 +332,7 @@ class Text_Diff_Engine_native {
         $i = 0;
         $j = 0;
 
-        assert('count($lines) == count($changed)');
+        assert(count($lines) == count($changed));
         $len = count($lines);
         $other_len = count($other_changed);
 
@@ -353,7 +353,7 @@ class Text_Diff_Engine_native {
             }
 
             while ($i < $len && ! $changed[$i]) {
-                assert('$j < $other_len && ! $other_changed[$j]');
+                assert($j < $other_len && ! $other_changed[$j]);
                 $i++; $j++;
                 while ($j < $other_len && $other_changed[$j]) {
                     $j++;
@@ -385,11 +385,11 @@ class Text_Diff_Engine_native {
                     while ($start > 0 && $changed[$start - 1]) {
                         $start--;
                     }
-                    assert('$j > 0');
+                    assert($j > 0);
                     while ($other_changed[--$j]) {
                         continue;
                     }
-                    assert('$j >= 0 && !$other_changed[$j]');
+                    assert($j >= 0 && !$other_changed[$j]);
                 }
 
                 /* Set CORRESPONDING to the end of the changed run, at the
@@ -410,7 +410,7 @@ class Text_Diff_Engine_native {
                         $i++;
                     }
 
-                    assert('$j < $other_len && ! $other_changed[$j]');
+                    assert($j < $other_len && ! $other_changed[$j]);
                     $j++;
                     if ($j < $other_len && $other_changed[$j]) {
                         $corresponding = $i;
@@ -426,11 +426,11 @@ class Text_Diff_Engine_native {
             while ($corresponding < $i) {
                 $changed[--$start] = 1;
                 $changed[--$i] = 0;
-                assert('$j > 0');
+                assert($j > 0);
                 while ($other_changed[--$j]) {
                     continue;
                 }
-                assert('$j >= 0 && !$other_changed[$j]');
+                assert($j >= 0 && !$other_changed[$j]);
             }
         }
     }

--- a/Text/Diff/Engine/shell.php
+++ b/Text/Diff/Engine/shell.php
@@ -85,7 +85,7 @@ class Text_Diff_Engine_shell {
 
             if ($from_line_no < $match[1] || $to_line_no < $match[4]) {
                 // copied lines
-                assert('$match[1] - $from_line_no == $match[4] - $to_line_no');
+                assert($match[1] - $from_line_no == $match[4] - $to_line_no);
                 array_push($edits,
                     new Text_Diff_Op_copy(
                         $this->_getLines($from_lines, $from_line_no, $match[1] - 1),


### PR DESCRIPTION
This pull request

- [x] stops using `string`s as arguments to `assert()`

💁‍♂️ For reference, see

- https://www.php.net/manual/en/migration72.deprecated.php#migration72.deprecated.assert-string-arg
- https://www.php.net/manual/en/migration80.incompatible.php#migration80.incompatible.standard