### PR TITLE
Fix: Do not use `each()`

### DIFF
--- a/Text/Diff/Engine/native.php
+++ b/Text/Diff/Engine/native.php
@@ -192,7 +192,7 @@ class Text_Diff_Engine_native {
                 }
                 $matches = $ymatches[$line];
                 reset($matches);
-                while (list(, $y) = each($matches)) {
+                foreach ($matches as list(, $y)) {
                     if (empty($this->in_seq[$y])) {
                         $k = $this->_lcsPos($y);
                         assert($k > 0);
@@ -200,7 +200,7 @@ class Text_Diff_Engine_native {
                         break;
                     }
                 }
-                while (list(, $y) = each($matches)) {
+                foreach ($matches as list(, $y)) {
                     if ($y > $this->seq[$k - 1]) {
                         assert($y <= $this->seq[$k]);
                         /* Optimization: this is a common case: next match is


### PR DESCRIPTION
This pull request 

- [x] stops using `each()`

💁‍♂️ For reference, see

- https://www.php.net/manual/en/migration72.deprecated.php#migration72.deprecated.each-function
- https://www.php.net/manual/en/migration80.incompatible.php#migration80.incompatible.core.other