### PR TITLE
Add .github workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+---
+name: Run Text_Diff Tests
+on:
+  push:
+  pull_request:
+    branches: [master]
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        php:
+          - 7.4
+          - 7
+          - 5.6
+          - 5.5
+          - 5.4
+          - 5.3
+        os: [ubuntu-latest, ubuntu-22.04]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: xdiff
+          tools: composer, PEAR
+      - name: Cache Composer packages
+        id: composer-cache
+        uses: actions/cache@v3
+        with:
+          path: vendor
+          key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-php-
+      - name: Run tests
+        run: |-
+          composer install
+          umask 0022
+          if [ ${{ matrix.php }} == 5.3 ] ; then
+            pear run-tests -r tests
+          else
+            pear run-tests -d -r tests
+          fi
+          pear package package.xml
+          composer validate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         os: [ubuntu-latest, ubuntu-22.04]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:


### PR DESCRIPTION
This adds a workflow to run the tests with github actions.

Versions < 5.6 fail apparently because of issues with how PEAR is provided in the test setups.

When excluding those lower versions, the [tests are fine](https://github.com/mdeweerd/Text_Diff/actions/runs/6075574091) (with the changes to `native.php` in #6).  When testing all versions, [5.5 and lower fail](https://github.com/mdeweerd/Text_Diff/actions/runs/6075546660/job/16481946834).  The issue are related to:
- `require_once(PEAR.php)` - No such file or dir in string.php;
- pear run-tests : unknown command

So the quick workaround is to remove versions 5.3,5.4 and 5.5 from the test matrix.  
My goal was to at least run some tests for different versions.