### PR TITLE
Fix: Do not install dependencies twice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,5 +35,4 @@ jobs:
           umask 0022
           sudo pear run-tests --ini=" -d include_path=.:/usr/share/php" -q -d -r ./tests
           pear package package.xml
-          composer install
           composer validate


### PR DESCRIPTION
This pull request

- [x] stops installing dependencies with `composer` twice